### PR TITLE
Test under JDK 25

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [ '17', '21', '24' ]
+        java: [ '17', '21', '24', '25-ea' ]
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,6 +21,8 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
+        check-latest: true
+        cache: 'gradle'
     - name: ./gradlew build javadoc
       run: ./gradlew build
     - name: ./gradlew requireJavadoc

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,9 @@ spotless {
   }
   java {
     targetExclude('**/WeakIdentityHashMap.java')
-    googleJavaFormat()
+    // googleJavaFormat()
+    // Version number required for Java 25.
+    googleJavaFormat('1.28.0')
     formatAnnotations()
   }
   groovyGradle {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Continuous integration now runs builds against Java 25 Early Access in addition to existing versions. This helps catch compatibility issues early across environments. There are no functional changes, features, or fixes in this release, and no impact on runtime behavior for users. This is a maintenance update only. No action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->